### PR TITLE
Enable pipenv in S2I

### DIFF
--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,0 +1,2 @@
+APP_CONFIG=config.py
+ENABLE_PIPENV=true

--- a/config.py
+++ b/config.py
@@ -1,0 +1,10 @@
+import os
+
+# pylama:ignore=C0103
+bind = '127.0.0.1:8000'
+
+workers = int(os.environ.get('GUNICORN_PROCESSES', '3'))
+threads = int(os.environ.get('GUNICORN_THREADS', '1'))
+
+forwarded_allow_ips = '*'
+secure_scheme_headers = {'X-Forwarded-Proto': 'https'}


### PR DESCRIPTION
Switch to `pipenv` in S2I config, so we won't need the `requirements.txt` anymore

Related: https://github.com/ManageIQ/aiops-deploy/pull/11, https://github.com/ManageIQ/aiops-data-collector/pull/5, https://github.com/ManageIQ/aiops-incoming-listener/pull/3