### PR TITLE
Swagger API for Publisher with minimal changes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 app = "*"
 flask = "*"
-marshmallow = "*"
+marshmallow = "~=2.17.0"
 requests = ">=2.20.0"
 "gunicorn" = "*"
 

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 app = "*"
 flask = "*"
+marshmallow = "*"
 requests = ">=2.20.0"
 "gunicorn" = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8f131e6b92114bb563b4b353145567bc279231f6633599bcc70bef9cbc8866b1"
+            "sha256": "9662a2748f14d063135118b81c8bcaf7cc4d67bfac3a3cbff179c3240ba39cce"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,10 +25,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
-                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
             ],
-            "version": "==2018.10.15"
+            "version": "==2018.11.29"
         },
         "chardet": {
             "hashes": [
@@ -62,10 +62,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
-                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
-            "version": "==2.7"
+            "version": "==2.8"
         },
         "itsdangerous": {
             "hashes": [
@@ -114,13 +114,21 @@
             ],
             "version": "==1.1.0"
         },
-        "requests": {
+        "marshmallow": {
             "hashes": [
-                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
-                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
+                "sha256:a2052f62b18f6dad520f465e437f63ab8812423975d48b9ebd30a735466e782a",
+                "sha256:e1b79eb3b815b49918c64114dda691b8767b48a1f66dd1d8c0cd5842b74257c2"
             ],
             "index": "pypi",
-            "version": "==2.20.1"
+            "version": "==2.16.3"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "index": "pypi",
+            "version": "==2.21.0"
         },
         "urllib3": {
             "hashes": [
@@ -307,18 +315,18 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:8e645abc9572749f0256f05db86af81ea2e3d583086cc2b73d241a64ecf571b7",
-                "sha256:f70e1b78240ba7fea809ecc00fbfbc51615ab531ef3f76f0548072c732358453"
+                "sha256:689de29ae747642ab230c6d37be2b969bf75663176658851f456619aacf27492",
+                "sha256:771467c434d0d9f081741fec1d64dfb011ed26e65e12a28fe06ca2f61c4d556c"
             ],
-            "version": "==2.2.1"
+            "version": "==2.2.2"
         },
         "pytest": {
             "hashes": [
-                "sha256:1d131cc532be0023ef8ae265e2a779938d0619bb6c2510f52987ffcba7fa1ee4",
-                "sha256:ca4761407f1acc85ffd1609f464ca20bb71a767803505bd4127d0e45c5a50e23"
+                "sha256:f689bf2fc18c4585403348dd56f47d87780bf217c53ed9ae7a3e2d7faa45f8e9",
+                "sha256:f812ea39a0153566be53d88f8de94839db1e8a05352ed8a49525d7d7f37861e9"
             ],
             "index": "pypi",
-            "version": "==4.0.1"
+            "version": "==4.0.2"
         },
         "pytest-cov": {
             "hashes": [
@@ -338,10 +346,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "version": "==1.11.0"
+            "version": "==1.12.0"
         },
         "snowballstemmer": {
             "hashes": [
@@ -352,32 +360,30 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:0948004fa228ae071054f5208840a1e88747a357ec1101c17217bfe99b299d58",
-                "sha256:10703d3cec8dcd9eef5a630a04056bbc898abc19bac5691612acba7d1325b66d",
-                "sha256:1f6c4bd0bdc0f14246fd41262df7dfc018d65bb05f6e16390b7ea26ca454a291",
-                "sha256:25d8feefe27eb0303b73545416b13d108c6067b846b543738a25ff304824ed9a",
-                "sha256:29464a177d56e4e055b5f7b629935af7f49c196be47528cc94e0a7bf83fbc2b9",
-                "sha256:2e214b72168ea0275efd6c884b114ab42e316de3ffa125b267e732ed2abda892",
-                "sha256:3e0d5e48e3a23e9a4d1a9f698e32a542a4a288c871d33ed8df1b092a40f3a0f9",
-                "sha256:519425deca5c2b2bdac49f77b2c5625781abbaf9a809d727d3a5596b30bb4ded",
-                "sha256:57fe287f0cdd9ceaf69e7b71a2e94a24b5d268b35df251a88fef5cc241bf73aa",
-                "sha256:668d0cec391d9aed1c6a388b0d5b97cd22e6073eaa5fbaa6d2946603b4871efe",
-                "sha256:68ba70684990f59497680ff90d18e756a47bf4863c604098f10de9716b2c0bdd",
-                "sha256:6de012d2b166fe7a4cdf505eee3aaa12192f7ba365beeefaca4ec10e31241a85",
-                "sha256:79b91ebe5a28d349b6d0d323023350133e927b4de5b651a8aa2db69c761420c6",
-                "sha256:8550177fa5d4c1f09b5e5f524411c44633c80ec69b24e0e98906dd761941ca46",
-                "sha256:898f818399cafcdb93cbbe15fc83a33d05f18e29fb498ddc09b0214cdfc7cd51",
-                "sha256:94b091dc0f19291adcb279a108f5d38de2430411068b219f41b343c03b28fb1f",
-                "sha256:a26863198902cda15ab4503991e8cf1ca874219e0118cbf07c126bce7c4db129",
-                "sha256:a8034021801bc0440f2e027c354b4eafd95891b573e12ff0418dec385c76785c",
-                "sha256:bc978ac17468fe868ee589c795d06777f75496b1ed576d308002c8a5756fb9ea",
-                "sha256:c05b41bc1deade9f90ddc5d988fe506208019ebba9f2578c622516fd201f5863",
-                "sha256:c9b060bd1e5a26ab6e8267fd46fc9e02b54eb15fffb16d112d4c7b1c12987559",
-                "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
-                "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
+                "sha256:0555eca1671ebe09eb5f2176723826f6f44cca5060502fea259de9b0e893ab53",
+                "sha256:0ca96128ea66163aea13911c9b4b661cb345eb729a20be15c034271360fc7474",
+                "sha256:16ccd06d614cf81b96de42a37679af12526ea25a208bce3da2d9226f44563868",
+                "sha256:1e21ae7b49a3f744958ffad1737dfbdb43e1137503ccc59f4e32c4ac33b0bd1c",
+                "sha256:37670c6fd857b5eb68aa5d193e14098354783b5138de482afa401cc2644f5a7f",
+                "sha256:46d84c8e3806619ece595aaf4f37743083f9454c9ea68a517f1daa05126daf1d",
+                "sha256:5b972bbb3819ece283a67358103cc6671da3646397b06e7acea558444daf54b2",
+                "sha256:6306ffa64922a7b58ee2e8d6f207813460ca5a90213b4a400c2e730375049246",
+                "sha256:6cb25dc95078931ecbd6cbcc4178d1b8ae8f2b513ae9c3bd0b7f81c2191db4c6",
+                "sha256:7e19d439fee23620dea6468d85bfe529b873dace39b7e5b0c82c7099681f8a22",
+                "sha256:7f5cd83af6b3ca9757e1127d852f497d11c7b09b4716c355acfbebf783d028da",
+                "sha256:81e885a713e06faeef37223a5b1167615db87f947ecc73f815b9d1bbd6b585be",
+                "sha256:94af325c9fe354019a29f9016277c547ad5d8a2d98a02806f27a7436b2da6735",
+                "sha256:b1e5445c6075f509d5764b84ce641a1535748801253b97f3b7ea9d948a22853a",
+                "sha256:cb061a959fec9a514d243831c514b51ccb940b58a5ce572a4e209810f2507dcf",
+                "sha256:cc8d0b703d573cbabe0d51c9d68ab68df42a81409e4ed6af45a04a95484b96a5",
+                "sha256:da0afa955865920edb146926455ec49da20965389982f91e926389666f5cf86a",
+                "sha256:dc76738331d61818ce0b90647aedde17bbba3d3f9e969d83c1d9087b4f978862",
+                "sha256:e7ec9a1445d27dbd0446568035f7106fa899a36f55e52ade28020f7b3845180d",
+                "sha256:f741ba03feb480061ab91a465d1a3ed2d40b52822ada5b4017770dfcb88f839f",
+                "sha256:fe800a58547dd424cd286b7270b967b5b3316b993d86453ede184a17b5a6b17d"
             ],
             "markers": "python_version < '3.7' and implementation_name == 'cpython'",
-            "version": "==1.1.0"
+            "version": "==1.1.1"
         },
         "wrapt": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9662a2748f14d063135118b81c8bcaf7cc4d67bfac3a3cbff179c3240ba39cce"
+            "sha256": "abe6fd7cce6a1ed8f174f4db14c35558515508a1c39f07ba6a3aa8ee5aa505f7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -116,11 +116,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:a2052f62b18f6dad520f465e437f63ab8812423975d48b9ebd30a735466e782a",
-                "sha256:e1b79eb3b815b49918c64114dda691b8767b48a1f66dd1d8c0cd5842b74257c2"
+                "sha256:abeebcb93e624c197302ce246d765dc2e2fea78220d1b8261d746d2216cfba0a",
+                "sha256:f8191486c56c6bb821d7b23a9c88ad2056faaf2f095d002beef2883e21a75d93"
             ],
             "index": "pypi",
-            "version": "==2.16.3"
+            "version": "==2.17.0"
         },
         "requests": {
             "hashes": [
@@ -255,11 +255,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
-                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
-                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
+                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
+                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
             ],
-            "version": "==4.3.0"
+            "version": "==5.0.0"
         },
         "pluggy": {
             "hashes": [

--- a/publish_json_schema/__init__.py
+++ b/publish_json_schema/__init__.py
@@ -1,0 +1,5 @@
+"""Publish JSON Schema interface."""
+
+from .publish_json_schema import PublishJSONSchema
+
+__all__ = ["PublishJSONSchema"]

--- a/publish_json_schema/publish_json_schema.py
+++ b/publish_json_schema/publish_json_schema.py
@@ -5,5 +5,5 @@ class PublishJSONSchema(Schema):
     """Schema for Publish."""
 
     id = fields.String(required=True)
-    data = fields.Raw(required=True)
+    data = fields.Dict(required=True)
     ai_service = fields.String()

--- a/publish_json_schema/publish_json_schema.py
+++ b/publish_json_schema/publish_json_schema.py
@@ -1,0 +1,9 @@
+from marshmallow import Schema, fields
+
+
+class PublishJSONSchema(Schema):
+    """Schema for Publish."""
+
+    id = fields.String(required=True)
+    data = fields.Raw(required=True)
+    ai_service = fields.String()

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,15 +1,6 @@
 swagger: '2.0'
 basePath: /
 paths:
-  /:
-    get:
-      responses:
-        '200':
-          description: Success
-      summary: Endpoint for Liveliness
-      operationId: get_liveliness
-      tags:
-        - default
   /api/v0/publish:
     post:
       responses:

--- a/swagger.yml
+++ b/swagger.yml
@@ -15,6 +15,8 @@ paths:
       responses:
         '200':
           description: Success
+        '400':
+          description: Input payload validation failed
       summary: Endpoint for upload and publish requests
       operationId: post_publish
       parameters:
@@ -60,8 +62,3 @@ definitions:
         type: string
         example: generic_ai
     type: object
-responses:
-  ParseError:
-    description: When a mask can't be parsed
-  MaskError:
-    description: When any error occurs on mask

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,0 +1,67 @@
+swagger: '2.0'
+basePath: /
+paths:
+  /:
+    get:
+      responses:
+        '200':
+          description: Success
+      summary: Endpoint for Liveliness
+      operationId: get_liveliness
+      tags:
+        - default
+  /api/v0/publish:
+    post:
+      responses:
+        '200':
+          description: Success
+      summary: Endpoint for upload and publish requests
+      operationId: post_publish
+      parameters:
+        - name: payload
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/PublishJSON'
+      tags:
+        - default
+  /api/v0/version:
+    get:
+      responses:
+        '200':
+          description: Success
+      summary: Endpoint for getting the current version
+      operationId: get_version
+      tags:
+        - default
+info:
+  title: AIOPS Publisher API
+  version: 0.0.1
+  description: AIOPS Publisher API
+produces:
+  - application/json
+consumes:
+  - application/json
+tags:
+  - name: default
+    description: Default namespace
+definitions:
+  PublishJSON:
+    required:
+      - id
+      - data
+    properties:
+      id:
+        type: string
+        example: '123'
+      data:
+        example: []
+      ai_service:
+        type: string
+        example: generic_ai
+    type: object
+responses:
+  ParseError:
+    description: When a mask can't be parsed
+  MaskError:
+    description: When any error occurs on mask

--- a/wsgi.py
+++ b/wsgi.py
@@ -19,6 +19,34 @@ ROOT_LOGGER.addHandler(default_handler)
 
 # Upload Service
 UPLOAD_SERVICE_ENDPOINT = os.environ.get('UPLOAD_SERVICE_ENDPOINT')
+
+
+def validate(input_data)-> dict:
+    """Validate input json."""
+    result = True
+    errors = {}
+    if 'id' not in input_data:
+        result = False
+        errors['id'] = "'id' is a required property"
+    elif not isinstance(input_data['id'], str):
+        result = False
+        errors['id'] = "'id' is not a string"
+
+    if 'data' not in input_data:
+        errors['data'] = "'data' is a required property"
+        result = False
+
+    if ('ai_service' in input_data and
+            not isinstance(input_data['ai_service'], str)):
+        errors['ai_service'] = "'ai_service' is not a string"
+        result = False
+
+    return {
+        "result": result,
+        "errors": errors
+    }
+
+
 @application.route('/', methods=['GET'])
 def get_liveliness():
     """Endpoint for Liveliness."""
@@ -41,6 +69,15 @@ def get_version():
 def post_publish():
     """Endpoint for upload and publish requests."""
     input_data = request.get_json(force=True)
+
+    validation = validate(input_data)
+    if validation['result'] is False:
+        return jsonify(
+            status='Error',
+            errors=validation['errors'],
+            message='Input payload validation failed'
+        ), 400
+
     data_id = input_data['id']
     ai_service_id = input_data.get('ai_service', 'generic_ai')
     raw_data = input_data['data']

--- a/wsgi.py
+++ b/wsgi.py
@@ -19,6 +19,13 @@ ROOT_LOGGER.addHandler(default_handler)
 
 # Upload Service
 UPLOAD_SERVICE_ENDPOINT = os.environ.get('UPLOAD_SERVICE_ENDPOINT')
+@application.route('/', methods=['GET'])
+def get_liveliness():
+    """Endpoint for Liveliness."""
+    return jsonify(
+        status='OK',
+        message='AIOPS Publisher is up and running!'
+    )
 
 
 @application.route("/", methods=['POST'])

--- a/wsgi.py
+++ b/wsgi.py
@@ -31,14 +31,6 @@ def validate(input_data)-> dict:
     return schema.load(input_data)
 
 
-@application.route('/', methods=['GET'])
-def get_liveliness():
-    """Endpoint for Liveliness."""
-    return jsonify(
-        status='OK',
-        message='AIOPS Publisher is up and running!'
-    )
-
 
 @application.route('/api/v0/version', methods=['GET'])
 def get_version():

--- a/wsgi.py
+++ b/wsgi.py
@@ -30,6 +30,13 @@ def get_liveliness():
 
 @application.route("/", methods=['POST'])
 def wake_up():
+@application.route('/api/v0/version', methods=['GET'])
+def get_version():
+    """Endpoint for getting the current version."""
+    return jsonify(
+        status='OK',
+        message='AIOPS Publisher Version 0.0.1'
+    )
     """Endpoint for upload and publish requests."""
     input_data = request.get_json(force=True)
     data_id = input_data['id']

--- a/wsgi.py
+++ b/wsgi.py
@@ -24,12 +24,8 @@ VERSION = "0.0.1"
 # Upload Service
 UPLOAD_SERVICE_ENDPOINT = os.environ.get('UPLOAD_SERVICE_ENDPOINT')
 
-
-def validate(input_data)-> dict:
-    """Validate input json."""
-    schema = PublishJSONSchema()
-    return schema.load(input_data)
-
+# Schema for the Publish API
+SCHEMA = PublishJSONSchema()
 
 
 @application.route('/api/v0/version', methods=['GET'])
@@ -46,8 +42,7 @@ def get_version():
 def post_publish():
     """Endpoint for upload and publish requests."""
     input_data = request.get_json(force=True)
-
-    validation = validate(input_data)
+    validation = SCHEMA.load(input_data)
     if validation.errors:
         return jsonify(
             status='Error',

--- a/wsgi.py
+++ b/wsgi.py
@@ -19,6 +19,8 @@ ROOT_LOGGER = logging.getLogger()
 ROOT_LOGGER.setLevel(application.logger.level)
 ROOT_LOGGER.addHandler(default_handler)
 
+VERSION = "0.0.1"
+
 # Upload Service
 UPLOAD_SERVICE_ENDPOINT = os.environ.get('UPLOAD_SERVICE_ENDPOINT')
 
@@ -43,6 +45,7 @@ def get_version():
     """Endpoint for getting the current version."""
     return jsonify(
         status='OK',
+        version=VERSION,
         message='AIOPS Publisher Version 0.0.1'
     )
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -28,8 +28,6 @@ def get_liveliness():
     )
 
 
-@application.route("/", methods=['POST'])
-def wake_up():
 @application.route('/api/v0/version', methods=['GET'])
 def get_version():
     """Endpoint for getting the current version."""
@@ -37,6 +35,10 @@ def get_version():
         status='OK',
         message='AIOPS Publisher Version 0.0.1'
     )
+
+
+@application.route("/api/v0/publish", methods=['POST'])
+def post_publish():
     """Endpoint for upload and publish requests."""
     input_data = request.get_json(force=True)
     data_id = input_data['id']


### PR DESCRIPTION
Implementation#3 for Swagger API

PR #11 and #12 are working examples of the Swagger API implementation using `connexion` and `flask-restplus` respectively.
While working on these PRs, the below observations were made -
- `connexion` added close to 20 Mibs of RAM, which seemed a tad expensive
- `flask-restplus` did not use swagger.yml and required the model to be declared in the python code itself along with some decorators applied to the methods

Both observations above were somewhat undesirable for us and hence we are now going with this implementation in the PR which will ensure that the microservice is as lightweight as possible with minimal changes and no additional libraries.

The PR contains -
- swagger.yml
- a Publish API - `/api/v0/publish`
- a version API - `api/v0/version`
- a liveliness endpoint (the index route itself) - `/`
- validation for the input json

Tests to follow in a separate PR which will be based on swagger.yml
