### PR TITLE
Aggregate metrics in the Multiprocess Mode (applicable to Gunicorn)

### DIFF
--- a/prometheus_metrics/__init__.py
+++ b/prometheus_metrics/__init__.py
@@ -1,5 +1,5 @@
 """Metrics interface."""
 
-from .prometheus_metrics import generate_latest_metrics, METRICS
+from .prometheus_metrics import generate_aggregated_metrics, METRICS
 
-__all__ = ["generate_latest_metrics", "METRICS"]
+__all__ = ["generate_aggregated_metrics", "METRICS"]

--- a/prometheus_metrics/prometheus_metrics.py
+++ b/prometheus_metrics/prometheus_metrics.py
@@ -1,5 +1,5 @@
-from prometheus_client import Counter, generate_latest
-from prometheus_client import CollectorRegistry, multiprocess
+from prometheus_client import (Counter, generate_latest,
+                               CollectorRegistry, multiprocess)
 
 
 # Prometheus Metrics

--- a/prometheus_metrics/prometheus_metrics.py
+++ b/prometheus_metrics/prometheus_metrics.py
@@ -1,4 +1,6 @@
 from prometheus_client import Counter, generate_latest
+from prometheus_client import CollectorRegistry, multiprocess
+
 
 # Prometheus Metrics
 METRICS = {
@@ -17,6 +19,8 @@ METRICS = {
 }
 
 
-def generate_latest_metrics():
-    """Generate Latest."""
-    return generate_latest()
+def generate_aggregated_metrics():
+    """Generate Aggregated Metrics for multiple processes."""
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry)
+    return generate_latest(registry)

--- a/wsgi.py
+++ b/wsgi.py
@@ -5,12 +5,28 @@ import tarfile
 import tempfile
 import json
 import re
+import sys
 
 from flask import Flask, jsonify, request
 from flask.logging import default_handler
 import requests
 
 from publish_json_schema import PublishJSONSchema
+
+# all gunicorn processes in a given instance need to access a common
+# folder in /tmp where the metrics can be recorded
+PROMETHEUS_MULTIPROC_DIR = '/tmp/aiops_publisher'
+
+try:
+    os.makedirs(PROMETHEUS_MULTIPROC_DIR, exist_ok=True)
+    os.environ['prometheus_multiproc_dir'] = PROMETHEUS_MULTIPROC_DIR
+except IOError as e:
+    # this is a non-starter for scraping metrics in the
+    # Multiprocess Mode (Gunicorn)
+    # terminate if there is an exception here
+    sys.exit("Error while creating prometheus_multiproc_dir: " + str(e))
+
+
 import prometheus_metrics
 
 application = Flask(__name__)  # noqa

--- a/wsgi.py
+++ b/wsgi.py
@@ -147,7 +147,7 @@ def post_publish():
 @application.route("/metrics", methods=['GET'])
 def get_metrics():
     """Metrics Endpoint."""
-    return prometheus_metrics.generate_latest_metrics()
+    return prometheus_metrics.generate_aggregated_metrics()
 
 
 if __name__ == '__main__':

--- a/wsgi.py
+++ b/wsgi.py
@@ -20,14 +20,13 @@ PROMETHEUS_MULTIPROC_DIR = '/tmp/aiops_publisher'
 try:
     os.makedirs(PROMETHEUS_MULTIPROC_DIR, exist_ok=True)
     os.environ['prometheus_multiproc_dir'] = PROMETHEUS_MULTIPROC_DIR
+    import prometheus_metrics
 except IOError as e:
     # this is a non-starter for scraping metrics in the
     # Multiprocess Mode (Gunicorn)
     # terminate if there is an exception here
     sys.exit("Error while creating prometheus_multiproc_dir: " + str(e))
 
-
-import prometheus_metrics
 
 application = Flask(__name__)  # noqa
 


### PR DESCRIPTION
After having observed how the `Counter` based metrics are scraped for other microservices like the Upload service, it was clear that aiops-publisher `Counter` metrics seemed a bit erroneous.

Counters go up, and reset when the process restarts.
Prior to this PR, you would see a counter metric in aiops-publisher `aiops_publisher_post_requests_total`, for example, going up and down and even plummeting down to zero sometimes and then back up, as shown below -

<img width="1437" alt="screen shot 2019-01-24 at 1 26 49 pm" src="https://user-images.githubusercontent.com/1538216/51709634-c5e61580-1fdb-11e9-909a-3c66856462ff.png">



It looks like the Gunicorn (which is used by aiops-publisher and other aiops microservices) operates in a multiprocess mode, causing the Counter metrics to go up and down.
(Upload service uses `tornado` and does not have this issue)

The `Multiprocess Mode (Gunicorn)` doc here - https://github.com/prometheus/client_python#multiprocess-mode-gunicorn was useful in resolving the above counter metrics issue. (I had seen this doc before, but wasn't aware that it would be applicable in our case)
The main idea is that each instance (and also each process in our case), would refer to the `prometheus_multiproc_dir` environment variable, which is a temporary file that keeps track of the metrics numbers. Using this temporary file, and other functions from the `prometheus_client` library such as - `CollectorRegistry` and `multiprocess`, we can correctly aggregate metrics across many processes in a single instance.

NOTE: While this works for our use case, per the doc https://github.com/prometheus/client_python#multiprocess-mode-gunicorn, this approach has some limitations

After applying this fix, the graph looks as shown below -
There are 2 Pods at `aiops_publisher_post_requests_total=4` and `aiops_publisher_post_requests_total=1`, each showing aggregated Counter metrics, as one would expect to see (as in, no ups and downs)

<img width="1427" alt="screen shot 2019-01-24 at 12 55 27 pm" src="https://user-images.githubusercontent.com/1538216/51709164-94207f00-1fda-11e9-8b3c-0608ecce6ceb.png">



