### PR TITLE
Add `x-rh-identity` to the POST request header

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -102,7 +102,10 @@ def post_publish():
         )
     }
 
-    headers = {'x-rh-insights-request-id': data_id}
+    b64_identity = request.headers.get('x-rh-identity')
+
+    headers = {'x-rh-insights-request-id': data_id,
+               'x-rh-identity': b64_identity}
 
     # send a POST request to upload service with files and headers info
     try:


### PR DESCRIPTION
With 3scale integration, we are required to pass the `x-rh-identity` value to the POST request header.

Identical changes were done here -
https://github.com/ManageIQ/aiops-data-collector/pull/19
https://github.com/ManageIQ/aiops-insights-clustering/pull/30

And last but not the least, now here in the Publisher

To conduct an end-to-end test, use the external 3scale supported URL with authentication as shown below -

```
curl --user <username>@redhat.com:<password> https://api.access.ci.cloud.paas.upshift.redhat.com/r/insights/platform/aiops-data-collector/api/v0/collect --data '{"url": "https://github.com/ManageIQ/aiops-data-collector/files/2755893/titanic.tar.gz"}'
```