### PR TITLE
Remove regular exp associated with ai_service

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -4,7 +4,6 @@ import io
 import tarfile
 import tempfile
 import json
-import re
 import sys
 from contextlib import suppress
 
@@ -125,7 +124,6 @@ def post_publish():
             message=error_msg
         ), 500
 
-    ai_service_id = re.sub(r'[^a-z]', r'', ai_service_id.lower())
     files = {
         'upload': (
             temp_file_name, open(temp_file_name, 'rb'),


### PR DESCRIPTION
The change here eventually leads to the results being published on this topic -
```
platform.upload.aiops-volume-type-validation
```
(as opposed to `platform.upload.ai_volumetype_validation`)

This will be very useful towards keeping the listener topic in the Consumer service generic.

Related: https://github.com/ManageIQ/aiops-dummy-ai-service/pull/16