### PR TITLE
GET route for `publish`

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -13,6 +13,10 @@ paths:
       tags:
       - default
   /api/v0/publish:
+    get:
+      responses:
+        '200':
+          description: Success
     post:
       responses:
         '200':

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,5 +1,6 @@
+import json
 import requests
-from wsgi import application
+from wsgi import application, VERSION
 
 # R0201 = Method could be a function Used when a method doesn't use its bound
 # instance, and so could be written as a function.
@@ -21,8 +22,13 @@ class TestRoot:
         mocker.patch('wsgi._retryable', side_effect=upload_response)
 
         response = client.get(url)
-        assert response.get_data() == \
-            b'{"message":"Up and Running","status":"OK","version":"0.0.1"}\n'
+
+        output = {
+            "message": "Up and Running",
+            "status": "OK",
+            "version": VERSION
+        }
+        assert json.loads(response.get_data()) == output
         assert response.status_code == 200
 
     def test_route_with_upload_service_error(self, mocker):
@@ -38,9 +44,13 @@ class TestRoot:
         mocker.patch('wsgi._retryable', side_effect=upload_response)
 
         response = client.get(url)
-        assert response.get_data() == \
-            b'{"message":"upload-service not operational",' \
-            b'"status":"Error","version":"0.0.1"}\n'
+
+        output = {
+            "message": "upload-service not operational",
+            "status": "Error",
+            "version": VERSION
+        }
+        assert json.loads(response.get_data()) == output
         assert response.status_code == 500
 
     def test_route_with_upload_service_absent(self, mocker):
@@ -50,9 +60,13 @@ class TestRoot:
         url = '/'
 
         response = client.get(url)
-        assert response.get_data() == \
-            b'{"message":"upload-service not operational",' \
-            b'"status":"Error","version":"0.0.1"}\n'
+
+        output = {
+            "message": "upload-service not operational",
+            "status": "Error",
+            "version": VERSION
+        }
+        assert json.loads(response.get_data()) == output
         assert response.status_code == 500
 
 
@@ -66,7 +80,11 @@ class TestGetPublish:
         url = '/api/v0/publish'
 
         response = client.get(url)
-        assert response.get_data() == b'{"message":"Requires a POST call ' \
-            b'to publish recommendations",' \
-            b'"status":"OK","version":"0.0.1"}\n'
+
+        output = {
+            "message": "Requires a POST call to publish recommendations",
+            "status": "OK",
+            "version": VERSION
+        }
+        assert json.loads(response.get_data()) == output
         assert response.status_code == 200

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -3,8 +3,9 @@ from wsgi import application
 
 # R0201 = Method could be a function Used when a method doesn't use its bound
 # instance, and so could be written as a function.
+# R0903 = Too few public methods
 
-# pylint: disable=R0201
+# pylint: disable=R0201,R0903
 
 
 class TestRoot:

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -70,21 +70,18 @@ class TestRoot:
         assert response.status_code == 500
 
 
-class TestGetPublish:
-    """Test various use cases for the index route."""
+def test_get_route_for_publish(mocker):
+    """Test GET Publish route."""
+    client = application.test_client(mocker)
 
-    def test_get_route_for_publish(self, mocker):
-        """Test index route when upload service is present."""
-        client = application.test_client(mocker)
+    url = '/api/v0/publish'
 
-        url = '/api/v0/publish'
+    response = client.get(url)
 
-        response = client.get(url)
-
-        output = {
-            "message": "Requires a POST call to publish recommendations",
-            "status": "OK",
-            "version": VERSION
-        }
-        assert json.loads(response.get_data()) == output
-        assert response.status_code == 200
+    output = {
+        "message": "Requires a POST call to publish recommendations",
+        "status": "OK",
+        "version": VERSION
+    }
+    assert json.loads(response.get_data()) == output
+    assert response.status_code == 200

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -53,3 +53,19 @@ class TestRoot:
             b'{"message":"upload-service not operational",' \
             b'"status":"Error","version":"0.0.1"}\n'
         assert response.status_code == 500
+
+
+class TestGetPublish:
+    """Test various use cases for the index route."""
+
+    def test_get_route_for_publish(self, mocker):
+        """Test index route when upload service is present."""
+        client = application.test_client(mocker)
+
+        url = '/api/v0/publish'
+
+        response = client.get(url)
+        assert response.get_data() == b'{"message":"Requires a POST call ' \
+            b'to publish recommendations",' \
+            b'"status":"OK","version":"0.0.1"}\n'
+        assert response.status_code == 200

--- a/wsgi.py
+++ b/wsgi.py
@@ -114,6 +114,16 @@ def get_version():
     )
 
 
+@application.route("/api/v0/publish", methods=['GET'])
+def get_publish():
+    """Endpoint for get route for publish."""
+    return jsonify(
+        status='OK',
+        version=VERSION,
+        message='Requires a POST call to publish recommendations'
+    )
+
+
 @application.route("/api/v0/publish", methods=['POST'])
 def post_publish():
     """Endpoint for upload and publish requests."""


### PR DESCRIPTION
A simple GET route `'/api/v0/publish'` was added which would be used by the AI Service to do it's 
liveness/readiness check