### PR TITLE
Fix Upload dependency check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import wsgi
 def patch_env(monkeypatch):
     """Set up environment."""
     # Set Test variables
-    monkeypatch.setenv('UPLOAD_SERVICE_API', 'http://upload:8080')
+    monkeypatch.setenv('UPLOAD_SERVICE', 'http://upload:8080')
+    monkeypatch.setenv('UPLOAD_SERVICE_PATH', 'api/ingress/v1')
 
     reload(wsgi)

--- a/wsgi.py
+++ b/wsgi.py
@@ -45,6 +45,7 @@ ROOT_LOGGER.setLevel(application.logger.level)
 VERSION = "0.0.1"
 
 # Upload Service
+UPLOAD_SERVICE = os.environ.get('UPLOAD_SERVICE')
 UPLOAD_SERVICE_API = os.environ.get('UPLOAD_SERVICE_API')
 
 # Schema for the Publish API
@@ -85,10 +86,7 @@ def _retryable(method: str, *args, **kwargs) -> requests.Response:
 def get_root():
     """Root Endpoint for Liveness/Readiness check."""
     try:
-        _retryable(
-            'get',
-            f'{UPLOAD_SERVICE_API}/upload',
-        )
+        _retryable('get', f'{UPLOAD_SERVICE}')
         status = 'OK'
         message = 'Up and Running'
         status_code = 200

--- a/wsgi.py
+++ b/wsgi.py
@@ -46,7 +46,7 @@ VERSION = "0.0.1"
 
 # Upload Service
 UPLOAD_SERVICE = os.environ.get('UPLOAD_SERVICE')
-UPLOAD_SERVICE_API = os.environ.get('UPLOAD_SERVICE_API')
+UPLOAD_SERVICE_PATH = os.environ.get('UPLOAD_SERVICE_PATH')
 
 # Schema for the Publish API
 SCHEMA = PublishJSONSchema()
@@ -173,7 +173,7 @@ def post_publish():
         prometheus_metrics.METRICS['posts'].inc()
         _retryable(
             'post',
-            f'{UPLOAD_SERVICE_API}/upload',
+            f'{UPLOAD_SERVICE}/{UPLOAD_SERVICE_PATH}/upload',
             files=files,
             headers=headers
         )


### PR DESCRIPTION
The Upload service ping route is now simply `/` on the Upload service
(the earlier GET route `http://upload-service.platform-ci.svc:8080/api/ingress/v1/upload` has been removed from the Upload service)

Some adjustments around the Upload service env variables were made
```
UPLOAD_SERVICE = http://upload-service.platform-ci.svc:8080
UPLOAD_SERVICE_PATH = api/ingress/v1
```

To be merged after the e2e-deploy PR goes in
e2e-deploy PR - https://github.com/RedHatInsights/e2e-deploy/pull/442